### PR TITLE
Use platform-agnostic temp path

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -207,7 +207,7 @@ Write-Host "✅ Will deploy to: $ResourceGroup / $AppName in $Location" -Foregro
 Write-Host ""
 
 # Create temp directory
-$TempDir = Join-Path $env:TEMP "SCIMTool-$(Get-Random)"
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "SCIMTool-$(Get-Random)"
 New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
 Push-Location $TempDir
 

--- a/scripts/deploy-azure.ps1
+++ b/scripts/deploy-azure.ps1
@@ -600,7 +600,7 @@ if (-not $skipAppDeployment) {
     $containerParams.blobBackupContainerName = $BlobBackupContainer
 
     # Create a temporary parameters file to avoid escaping issues with special characters
-    $paramsFile = "$env:TEMP\scimtool-params-$(Get-Date -Format 'yyyyMMddHHmmss').json"
+    $paramsFile = Join-Path ([System.IO.Path]::GetTempPath()) "scimtool-params-$(Get-Date -Format 'yyyyMMddHHmmss').json"
     $paramsJson = @{
         '$schema' = 'https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#'
         contentVersion = '1.0.0.0'

--- a/setup.ps1
+++ b/setup.ps1
@@ -167,7 +167,7 @@ Write-Host "  OAuth Secret  : $OauthClientSecret" -ForegroundColor Yellow
 Stage a temporary directory structure so the deployment script's relative
 references to ../infra/*.bicep resolve even when fetched remotely.
 #>
-$tempRoot = Join-Path $env:TEMP ("scimtool-" + ([guid]::NewGuid().ToString('N')))
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("scimtool-" + ([guid]::NewGuid().ToString('N')))
 $scriptsDir = Join-Path $tempRoot 'scripts'
 $infraDir   = Join-Path $tempRoot 'infra'
 New-Item -ItemType Directory -Path $scriptsDir -Force | Out-Null


### PR DESCRIPTION
Fix deployment scripts for unix incl. Azure Cloud Shell by replacing Windows-specific temp variable with platform agnostic alternative.

_Script deploy.ps1 has not been tested. Just fixed all occurences._